### PR TITLE
Fix resizing of images

### DIFF
--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -15,6 +15,7 @@
     <link href="/css/HPstyles.css" rel="stylesheet">
     <link href="/css/hugofont.css" rel="stylesheet">
     <link href="/css/owl.theme.default.css" rel="stylesheet">
+    <link href="/css/custom.css" rel="stylesheet">
     <link rel="shortcut icon" href="/favicon.ico" type="image/x-icon" />
     <link rel="apple-touch-icon" href="/apple-touch-icon.png" />
   </head>

--- a/static/css/custom.css
+++ b/static/css/custom.css
@@ -1,0 +1,4 @@
+img {
+    max-width: 100%;
+    height: auto;
+}

--- a/static/css/custom.css
+++ b/static/css/custom.css
@@ -2,3 +2,8 @@ img {
     max-width: 100%;
     height: auto;
 }
+
+ul {
+    list-style-position: inside;
+    padding-left: 0;
+}


### PR DESCRIPTION
They should never be wider than 100% of the screen.

This should hopefully fix the image size on mobile devices.