### PR TITLE
Fix linebreaks in download links

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: go
-env: HUGO_VERSION=0.49.2
+env: HUGO_VERSION=0.69.2
 notifications:
   email:
     on_success: change
@@ -20,4 +20,3 @@ deploy:
   target_branch: master
   on:
     branch: source
-

--- a/content/download/index.md
+++ b/content/download/index.md
@@ -10,21 +10,21 @@ for installation and usage instructions.
 
 # <i class="icon-windows8"></i> Windows
 
-### <i class="icon-install"></i> [Download LibrePCB Installer for Windows](https://download.librepcb.org/releases/{{< latest_version >}}/librepcb-installer-{{< latest_version >}}-windows-x86.exe)
+### <i class="icon-install"></i> [Download LibrePCB Installer for Windows](https://download.librepcb.org/releases/{{< param latestVersion >}}/librepcb-installer-{{< param latestVersion >}}-windows-x86.exe)
 
-Alternative: [Portable ZIP](https://download.librepcb.org/releases/{{< latest_version >}}/librepcb-{{< latest_version >}}-windows-x86.zip) (extract & run)
+Alternative: [Portable ZIP](https://download.librepcb.org/releases/{{< param latestVersion >}}/librepcb-{{< param latestVersion >}}-windows-x86.zip) (extract & run)
 
 
 # <i class="icon-tux"></i> Linux
 
-### <i class="icon-install"></i> [Download LibrePCB Installer for Linux](https://download.librepcb.org/releases/{{< latest_version >}}/librepcb-installer-{{< latest_version >}}-linux-x86_64.run)
+### <i class="icon-install"></i> [Download LibrePCB Installer for Linux](https://download.librepcb.org/releases/{{< param latestVersion >}}/librepcb-installer-{{< param latestVersion >}}-linux-x86_64.run)
 
 Alternatives for various distributions:
 [Snap](https://snapcraft.io/librepcb),
 [Flatpak](https://flathub.org/apps/details/org.librepcb.LibrePCB),
-[AppImage](https://download.librepcb.org/releases/{{< latest_version >}}/librepcb-{{< latest_version >}}-linux-x86_64.AppImage)
+[AppImage](https://download.librepcb.org/releases/{{< param latestVersion >}}/librepcb-{{< param latestVersion >}}-linux-x86_64.AppImage)
 (set executable flag & run) or
-[binary archive](https://download.librepcb.org/releases/{{< latest_version >}}/librepcb-{{< latest_version >}}-linux-x86_64.tar.gz).
+[binary archive](https://download.librepcb.org/releases/{{< param latestVersion >}}/librepcb-{{< param latestVersion >}}-linux-x86_64.tar.gz).
 
 **Arch Linux:** [librepcb](https://aur.archlinux.org/packages/librepcb/) (builds from source)
 or [librepcb-appimage](https://aur.archlinux.org/packages/librepcb-appimage/) (downloads binary)
@@ -42,15 +42,15 @@ from OpenPandora Repository
 
 # <i class="icon-apple"></i> MacOS
 
-### <i class="icon-install"></i> [Download LibrePCB Installer for MacOS](https://download.librepcb.org/releases/{{< latest_version >}}/librepcb-installer-{{< latest_version >}}-mac-x86_64.dmg)
+### <i class="icon-install"></i> [Download LibrePCB Installer for MacOS](https://download.librepcb.org/releases/{{< param latestVersion >}}/librepcb-installer-{{< param latestVersion >}}-mac-x86_64.dmg)
 
-Alternative: [App Bundle](https://download.librepcb.org/releases/{{< latest_version >}}/librepcb-{{< latest_version >}}-mac-x86_64.dmg)
+Alternative: [App Bundle](https://download.librepcb.org/releases/{{< param latestVersion >}}/librepcb-{{< param latestVersion >}}-mac-x86_64.dmg)
 
 
 # <i class="icon-code"></i> Source
 
 Alternatively you could build LibrePCB from
-[sources](https://download.librepcb.org/releases/{{< latest_version >}}/librepcb-{{< latest_version >}}-source.zip).
+[sources](https://download.librepcb.org/releases/{{< param latestVersion >}}/librepcb-{{< param latestVersion >}}-source.zip).
 The Git repository is hosted [at GitHub](https://github.com/LibrePCB/LibrePCB).
 
 See [README.md](https://github.com/LibrePCB/LibrePCB/blob/master/README.md)

--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -1,7 +1,7 @@
 {{ partial "header.html" . }}
 {{ partial "top-block.html" . }}
 
-{{ range $index, $element := where .Data.Pages "Section" "post" }}
+{{ range $index, $element := where .Site.Pages "Section" "post" }}
   <div id="main">
     {{ if modBool $index 2 }}<div id="intro" class="counterpoint">{{ else }}<div id="intro" class="point">{{ end }}
       <div class="container">

--- a/layouts/shortcodes/latest_version.html
+++ b/layouts/shortcodes/latest_version.html
@@ -1,1 +1,0 @@
-{{ .Site.Params.latestVersion }}


### PR DESCRIPTION
The placeholder `{{< latest_version >}}` lead to linebreaks in hyperlinks. With newer Hugo versions there is a `param` shortcode, that's simpler and works better, so I updated Hugo to the latest version.